### PR TITLE
Fix: Glitches when seeking on safari

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -63,6 +63,16 @@
     </div>
 
     <br />
+    <label>Example progress bar</lable>
+    <input 
+      type="range"
+      id="progress-bar"
+      name="progress-bar"
+      min="0"
+      max="100"
+      value="0"
+      />
+    <br/>
 
     <p>
       Easily add alternative audio tracks like languages or commentary by adding
@@ -72,7 +82,16 @@
     <br />
 
     <script>
+      const progressBar = document.getElementById('progress-bar');
       let controller;
+
+      progressBar.addEventListener("change",(e)=>{
+        if(controller){
+          controller = video.groupController;
+        }
+        controller.currentTime = e.target.value;
+      })
+
       document
         .querySelector('#media-group-script')
         .addEventListener('load', () => {
@@ -104,6 +123,10 @@
           controller.addEventListener('waiting', (e) => {
             console.log(e.type);
           });
+
+          controller.addEventListener('timeupdate',(e)=>{
+            progressBar.value = controller.currentTime;
+          })
 
           playbtn.onclick = () => {
             if (controller.playbackState === 'waiting') {

--- a/examples/style.css
+++ b/examples/style.css
@@ -32,3 +32,7 @@ pre[class^='language-'] {
   overflow-x: auto;
   border-radius: 5px;
 }
+
+input#progress-bar{
+  width: 100%;
+}

--- a/src/media-group-controller.ts
+++ b/src/media-group-controller.ts
@@ -306,7 +306,7 @@ export class MediaGroupController extends EventTarget {
         // https://www.prosoundtraining.com/site/wp-content/uploads/2014/02/Lip-Sync-Errors.pdf
         // Safari is very difficult to get synced so close.
         // Working with playbackRate is impossible on Safari, try with seeking.
-        const target = child.dataset.groupSeekPrecision ?? 0.05;
+        const target = child.dataset.groupSeekPrecision ?? 0.5;
         const offset = 0;
         const targetTime = sourceTime + offset / 1000;
         const currentTime = child.currentTime;


### PR DESCRIPTION
following up from https://github.com/muxinc/media-group/issues/69 here's a PR that seems to fix the glitch in safari.

Open the [example](https://media-group-mux.vercel.app/examples/) in safari and click on the progress bar of either the video or audio track - you'd notice some glitches. 

In this PR we adjust the `groupSeekPrecision` for safari from `0.05` to `0.5`, to reduce the amount of time safari tries to adjust the playback position under the hood causing these glitches, and it seems to work. 🥳 

<details><summary>high level explanation</summary>

Suggestion 

>Tune `groupSeekPrecision`: Currently, the groupSeekPrecision defaults to `0.05`, but Safari might benefit from a higher value. Try setting media.dataset.groupSeekPrecision to a slightly larger threshold, like `0.1` or `0.15`, to reduce rapid adjustments and achieve smoother seeks."

Explanation
>The recommendation to "tune groupSeekPrecision" specifically for Safari arises because Safari tends to handle currentTime synchronization differently than other browsers. A higher precision threshold helps mitigate Safari's tendency to make frequent, tiny adjustments during seeks. Here’s why and how this adjustment can help:
>
>1. Minimizing Frequent Adjustments: A small groupSeekPrecision (e.g., 0.05 seconds) enforces a strict synchronization threshold, causing frequent updates to currentTime whenever even minor discrepancies occur. In Safari, this can lead to "glitchy" behavior, particularly for audio, because the player tries to correct these tiny discrepancies too often.
>
>2. Reducing Rapid Re-Seeking in Safari: Safari’s media buffering and seeking mechanisms can struggle with quick, repetitive changes in currentTime. By slightly increasing groupSeekPrecision to, say, 0.1 or 0.15, you relax the tolerance for synchronization. This allows a more forgiving interval in which the media elements can stay slightly out of sync without triggering constant adjustments.
>
>3. Smoother Seeks in Safari: By reducing the frequency of these adjustments, a higher groupSeekPrecision value enables a smoother seeking experience, especially in multi-element groups (e.g., audio and video tracks in sync). Safari responds better when the synchronization threshold allows slight deviations during rapid seeks.
</details>

to try locally after cloning and pulling the branch.
```
npm install
```
```
npm run dev
```
visit http://127.0.0.1:8000/examples/